### PR TITLE
Add `make opam-deps-opt` to INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,6 +70,7 @@ Install the dependencies via OPAM. A helper `make` target is present for that:
 ```{bash}
 make opam-update
 make opam-deps
+make opam-deps-opt
 ```
 
 Compile the embedded dependencies and TLAPM:


### PR DESCRIPTION
I encountered the following errors after pulling the latest commits from main. I manually installed `eio_main` with `opam install eio_main` and `lsp` with `opam install lsp` before noticing `make opam-deps-opt`:

```shell
-> % make
dune build
File "lsp/bin/dune", line 7, characters 26-34:
7 |  (libraries tlapm_lsp_lib eio_main cmdliner))
                              ^^^^^^^^
Error: Library "eio_main" not found.
-> required by _build/default/lsp/bin/tlapm_lsp.exe
-> required by alias lsp/bin/all
-> required by alias default
make: *** [build] Error 1
```

```shell
dune build
File "lsp/bin/dune", line 7, characters 12-25:
7 |  (libraries tlapm_lsp_lib eio_main cmdliner))
                ^^^^^^^^^^^^^
Error: Library "tlapm_lsp_lib" in _build/default/lsp/lib is hidden (optional
with unavailable dependencies).
-> required by _build/default/lsp/bin/tlapm_lsp.exe
-> required by alias lsp/bin/all
-> required by alias default
make: *** [build] Error 1
```